### PR TITLE
contact telecom build bug: 

### DIFF
--- a/input/security-gov-regs.xml
+++ b/input/security-gov-regs.xml
@@ -13,7 +13,7 @@
   <contact>
     <telecom>
       <!-- Or whatever URL and/or email address(es) are appropriate -->
-      <system value="other"/>
+      <system value="url"/>
       <value value="http://hl7.org/Special/committees/security"/>
     </telecom>
   </contact>


### PR DESCRIPTION
`First "url" contact telecom must start with "http://hl7.org/Special/committees/"`